### PR TITLE
Limit plant suggestion search to plants

### DIFF
--- a/census/api/src/api/identification.ts
+++ b/census/api/src/api/identification.ts
@@ -58,15 +58,20 @@ export const createIdentificationRouter = () =>
         ctx.points();
       }),
     searchForTaxa: procedure
-      .input(z.object({ query: z.string() }))
+      .input(z.object({ query: z.string(), taxonId: z.number().optional() }))
       .use(
         cache.query({
-          key: ({ input }) => ['inat', 'taxaSearch', input.query.trim().toLowerCase()],
+          key: ({ input }) => [
+            'inat',
+            'taxaSearch',
+            input.query.trim().toLowerCase(),
+            input.taxonId?.toString() ?? 'all'
+          ],
           ttl: 60 * 60
         })
       )
       .query(async ({ input }) => {
-        return await getTaxaFromPartialSearch(input.query);
+        return await getTaxaFromPartialSearch(input.query, input.taxonId);
       }),
 
     identificationsGroupedBySource: procedure

--- a/census/api/src/services/inat/index.ts
+++ b/census/api/src/services/inat/index.ts
@@ -32,8 +32,11 @@ const SearchResults = z.object({
 
 export type TaxaSearchResult = z.infer<typeof TaxaSearchResult>;
 
-export const getTaxaFromPartialSearch = async (search: string) => {
-  const response = await fetch(`https://api.inaturalist.org/v1/taxa/autocomplete?q=${encodeURIComponent(search)}`);
+export const getTaxaFromPartialSearch = async (search: string, taxonId?: number) => {
+  const params = new URLSearchParams({ q: search });
+  if (taxonId) params.set('taxon_id', taxonId.toString());
+
+  const response = await fetch(`https://api.inaturalist.org/v1/taxa/autocomplete?${params.toString()}`);
   const data = await response.json();
   return SearchResults.parse(data);
 };

--- a/census/website/src/components/forms/inputs/INatTaxaInput.tsx
+++ b/census/website/src/components/forms/inputs/INatTaxaInput.tsx
@@ -1,4 +1,5 @@
 import SiBinoculars from '@/components/icons/SiBinoculars';
+import SiSearchGlobe from '@/components/icons/SiSearchGlobe';
 import { useAPI } from '@/services/query/hooks';
 import { cn } from '@/utils/cn';
 import { useQuery } from '@tanstack/react-query';
@@ -12,6 +13,7 @@ export interface InputProps<T> {
   placeholder?: string;
   autoOpen?: boolean;
   icon?: ReactNode;
+  taxonId?: number;
 }
 
 interface TaxaSearchResult {
@@ -26,6 +28,7 @@ export const INatTaxaInput: FC<InputProps<TaxaSearchResult> & Omit<ComponentProp
   onSelect,
   placeholder,
   autoOpen,
+  taxonId,
   ...props
 }) => {
   const [query, setQuery] = useState('');
@@ -37,8 +40,8 @@ export const INatTaxaInput: FC<InputProps<TaxaSearchResult> & Omit<ComponentProp
   const api = useAPI();
 
   const results = useQuery({
-    queryKey: ['inat-taxa', search],
-    queryFn: () => api.identification.searchForTaxa.query({ query: search }),
+    queryKey: ['inat-taxa', search, taxonId],
+    queryFn: () => api.identification.searchForTaxa.query({ query: search, taxonId }),
     enabled: !!search
   });
 
@@ -93,7 +96,7 @@ export const INatTaxaInput: FC<InputProps<TaxaSearchResult> & Omit<ComponentProp
                     <Command.Group>
                       {results.data?.results.map(result => (
                         <Command.Item
-                          className="px-3 py-1 cursor-pointer data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent-100 data-[disabled=true]:opacity-50"
+                          className="flex cursor-pointer items-center justify-between gap-2 px-3 py-1 data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent-100 data-[disabled=true]:opacity-50"
                           key={result.id}
                           value={result.name}
                           onSelect={() => {
@@ -107,8 +110,27 @@ export const INatTaxaInput: FC<InputProps<TaxaSearchResult> & Omit<ComponentProp
                             setQuery('');
                           }}
                         >
-                          <p className="text-sm">{result.preferred_common_name}</p>
-                          <p className="text-xs opacity-75">{result.name}</p>
+                          <div className="min-w-0">
+                            <p className="truncate text-sm">{result.preferred_common_name ?? result.name}</p>
+                            <p className="truncate text-xs opacity-75">{result.name}</p>
+                          </div>
+                          <a
+                            href={`https://www.inaturalist.org/taxa/${result.id}`}
+                            target="_blank"
+                            rel="noreferrer"
+                            aria-label={`open ${result.name} on iNaturalist`}
+                            title="Open on iNaturalist"
+                            onPointerDown={event => event.stopPropagation()}
+                            onMouseDown={event => event.stopPropagation()}
+                            onClick={event => event.stopPropagation()}
+                            className="relative flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-accent-800 hover:bg-accent-200"
+                          >
+                            <span
+                              aria-hidden="true"
+                              className="pointer-events-none absolute left-1/2 top-1/2 h-12 w-12 -translate-x-1/2 -translate-y-1/2 sm:hidden"
+                            />
+                            <SiSearchGlobe className="text-lg" />
+                          </a>
                         </Command.Item>
                       ))}
                     </Command.Group>

--- a/census/website/src/pages/observations/Observation.tsx
+++ b/census/website/src/pages/observations/Observation.tsx
@@ -81,6 +81,8 @@ const buildIdentificationTree = (identifications: IdentificationType[]) => {
   return nodes.filter(node => node.isRoot());
 };
 
+const PLANT_TAXON_ID = 47126;
+
 const UserLinkList: FC<{ users: { id: number; username: string }[] }> = ({ users }) => {
   return (
     <>
@@ -306,6 +308,7 @@ export const Observation: FC<ObservationProps> = ({ observation }) => {
               <INatTaxaInput
                 icon={<SiLeaf className="text-2xl" />}
                 placeholder="suggest plant"
+                taxonId={PLANT_TAXON_ID}
                 onSelect={async taxon => {
                   await suggestAccessoryIdentification.mutateAsync({
                     observationId: observation.id,


### PR DESCRIPTION
## Summary

Limit the accessory plant suggestion search to the iNaturalist plant taxon so users are only offered plant results when adding associated plants.

## Changes

- Add an optional `taxonId` parameter to the `identification.searchForTaxa` API and include it in cache keys.
- Forward `taxon_id` to the iNaturalist taxa autocomplete endpoint when provided.
- Pass the plant taxon id from the observation accessory plant input while leaving the normal identification search unrestricted.
- Add an iNaturalist link action on taxa search results so suggestions can be opened directly.

## Impact

Plant accessory suggestions should no longer surface non-plant taxa, while regular observation identification suggestions continue to search all taxa.

## Validation

- Passed: `git diff --check origin/main...HEAD`
- Passed: `pnpm --filter @alveusgg/census-website build`
- Note: `pnpm fmt:check` currently fails on existing formatting issues across unrelated files; I did not change those in this PR.