### PR TITLE
(fix): sign-up link icon alignment on home page

### DIFF
--- a/census/website/src/pages/home/Home.tsx
+++ b/census/website/src/pages/home/Home.tsx
@@ -78,7 +78,7 @@ export const Home: FC = () => {
                 <span>submit new clip</span>
               </Button>
             ) : (
-              <Link to="/forms/onboarding" className="mt-4 w-fit px-4 text-center">
+              <Link to="/forms/onboarding" className="mt-4 flex w-fit items-center gap-1 px-4 text-center">
                 <span>Sign up to help out!</span>
                 <ChevronRight className="size-4" />
               </Link>


### PR DESCRIPTION
Fixed the "Sign up to help out!" button on the home page, the text and arrow icon were stacking vertically instead of sitting inline. Added flex items-center to the link so they align correctly side by side.

<img width="717" height="240" alt="image" src="https://github.com/user-attachments/assets/76368db2-9fad-4d35-899d-ed83c9553df9" />
